### PR TITLE
Allow for -ve longitudes

### DIFF
--- a/nwp/sounding/app.py
+++ b/nwp/sounding/app.py
@@ -141,7 +141,7 @@ def parameter_all_levels(model, latitude, longitude, run_hour, run_datetime, tim
     return data
 
 
-@app.route("/<float:latitude>/<float:longitude>/<int:run_hour>/<int:run_datetime>/<int:timestep>/<parameter>")
+@app.route("/<float:latitude>/<float(signed=True):longitude>/<int:run_hour>/<int:run_datetime>/<int:timestep>/<parameter>")
 def sounding(latitude, longitude, run_hour, run_datetime, timestep, parameter):
     with tracer.span(name="sounding") as span:
         span.add_attribute("latitude", str(latitude))


### PR DESCRIPTION
Could you please allow for -ve longitudes? The default behaviour for parsing floats is to return a 404